### PR TITLE
Fix create-service binary path quotes

### DIFF
--- a/scripts/create-service.ps1
+++ b/scripts/create-service.ps1
@@ -4,7 +4,7 @@ if ($args.Count -ne 1) {
 
 $params = @{
     Name           = "DropIt"
-    BinaryPathName = "'$($args[0])'"
+    BinaryPathName = "`"$($args[0])`""
     DisplayName    = "Drop It"
     StartupType    = "AutomaticDelayedStart"
     Description    = "Remote shutdown service"


### PR DESCRIPTION
New-Service cmdlet requires double inner quotes for the BinaryPathName
parameter.